### PR TITLE
feat: add attestation logging

### DIFF
--- a/beacon-chain/blockchain/SOLUTION.md
+++ b/beacon-chain/blockchain/SOLUTION.md
@@ -1,0 +1,47 @@
+# Task
+Prysm is not verifying attestations correctly. Add logging for the attestations.
+
+- Counts successfully verified attestations.
+- Counts failed attestations and records the reason for each failure.
+- Outputs a summary of the collected data at the end of each epoch.
+
+## Solution
+My idea is to record the attestion in the `beacon-chain/blockchain`. This directory has the service that handles the internal logic of managing the full PoS beacon chain. It will start logging the attestation count of the incoming new slot right after the deployment.
+
+1. Added `beacon-chain/blockchain/attestations_stats.go`
+- Create new struct AttestationsStats
+- In-memory storage to collect the successful count, failed count and failed resason.
+- It can also generate log report with function - ReportEpochTransition
+2. Modified `beacon-chain/blockchain/receive_attestation.go`
+- add `attestationsStats.AddFailure()` and `attestationsStats.AddSuccess()` in func `processAttestations`
+- It is recording the attestation count on receive attestation
+3. Modified `beacon-chain/blockchain/receive_block.go`
+- added `attestationsStats.ReportEpochTransition()` in `updateCheckpoints`
+- it is generating a report for the attestion count for every epoch
+4. Modified `beacon-chain/blockchain/service.go`
+- added attestationsStats to Service struct
+- add initialation of attestationsStats to `NewService`
+
+## Example Log Output
+```
+time="2024-11-16T02:21:53+01:00" level=info msg="Attestation Summary for Epoch 1:" prefix=blockchain
+time="2024-11-16T02:21:53+01:00" level=info msg="  Successful Attestations Count: 2" prefix=blockchain
+time="2024-11-16T02:21:53+01:00" level=info msg="  Failed Attestations Count: 2" prefix=blockchain
+time="2024-11-16T02:21:53+01:00" level=info msg="  error: failed to attestation" aggregatedCount=1 beaconBlockRoot=1 committeeCount=1 committeeIndices=1 prefix=blockchain slot=1 targetRoot=1
+time="2024-11-16T02:21:53+01:00" level=info msg="  error: failed to attestation" aggregatedCount=2 beaconBlockRoot=2 committeeCount=2 committeeIndices=2 prefix=blockchain slot=2 targetRoot=2
+time="2024-11-16T02:21:53+01:00" level=info msg="Attestation Summary for Epoch 2:" prefix=blockchain
+time="2024-11-16T02:21:53+01:00" level=info msg="  Successful Attestations Count: 6" prefix=blockchain
+time="2024-11-16T02:21:53+01:00" level=info msg="  Failed Attestations Count: 0" prefix=blockchain
+```
+
+## Test
+Unit test: `beacon-chain/blockchain/attestations_stats_test.go`
+
+Todo:
+- add unit test in beacon-chain/blockchain/service_test.go to fully test the logging for attestation
+- add integration to test if the node can log attestion properly
+
+## Improvement
+- make the log report in a prettier format
+- it could be tough to gather the attestation from the log, it could also be collected in the local directry of the node as a separated file to append the counts.
+- the logging could be also added to `beacon-chain/sync`, if we want to have the attestion logging from a new beacon node from genesis block.

--- a/beacon-chain/blockchain/attestations_stats.go
+++ b/beacon-chain/blockchain/attestations_stats.go
@@ -1,0 +1,70 @@
+package blockchain
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// AttestationsStats represents the stat for every epoch of successful and failed attestation counts
+// It records on receiving Attestation in this package file: receive_attestation.go - function: processAttestations
+// It prints out the stat for every epoch and stat is reset.
+type AttestationsStats struct {
+	mu                 sync.Mutex
+	successfulCount    int
+	failedCount        int
+	failedAttestations []FailedAttestation
+}
+
+// FailedAttestation represents the failed reason for the attestation
+// It is used to debug the attestation of this node operation
+type FailedAttestation struct {
+	Fields logrus.Fields
+	Error  error
+}
+
+// NewAttestationsStats instantiates a new AttestationsStats
+func NewAttestationsStats() *AttestationsStats {
+	return &AttestationsStats{
+		mu:                 sync.Mutex{},
+		successfulCount:    0,
+		failedCount:        0,
+		failedAttestations: []FailedAttestation{},
+	}
+}
+
+// AddSuccess add successfulCount to AttestationsStats
+func (a *AttestationsStats) AddSuccess() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.successfulCount += 1
+}
+
+// AddFailure add failedCount and append FailedAttestation to AttestationsStats
+func (a *AttestationsStats) AddFailure(f FailedAttestation) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.failedCount += 1
+	a.failedAttestations = append(a.failedAttestations, f)
+}
+
+// ReportEpochTransition generate report of AttestationsStats to log
+// It also resets the stats
+func (a *AttestationsStats) ReportEpochTransition(currentEpoch uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	log.Infof("Attestation Summary for Epoch %d:", currentEpoch)
+	log.Infof("  Successful Attestations Count: %d", a.successfulCount)
+	log.Infof("  Failed Attestations Count: %d", a.failedCount)
+	for _, v := range a.failedAttestations {
+		log.WithFields(v.Fields).Infof("  error: %s", v.Error.Error())
+	}
+
+	// reset stats
+	a.successfulCount = 0
+	a.failedCount = 0
+	a.failedAttestations = []FailedAttestation{}
+}

--- a/beacon-chain/blockchain/attestations_stats_test.go
+++ b/beacon-chain/blockchain/attestations_stats_test.go
@@ -1,0 +1,98 @@
+package blockchain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/testing/assert"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestAddSuccess(t *testing.T) {
+	a := NewAttestationsStats()
+
+	a.AddSuccess()
+	a.AddSuccess()
+
+	assert.Equal(t, 2, a.successfulCount)
+}
+
+func TestFailure(t *testing.T) {
+	a := NewAttestationsStats()
+
+	a.AddFailure(FailedAttestation{})
+	a.AddFailure(FailedAttestation{})
+
+	assert.Equal(t, 2, a.failedCount)
+	assert.Equal(t, 2, len(a.failedAttestations))
+}
+
+func TestReportEpochTransition(t *testing.T) {
+	hook := logtest.NewGlobal()
+
+	a := NewAttestationsStats()
+
+	a.AddSuccess()
+	a.AddSuccess()
+
+	a.AddFailure(FailedAttestation{
+		Fields: logrus.Fields{
+			"slot":             "1",
+			"committeeCount":   "1",
+			"committeeIndices": "1",
+			"beaconBlockRoot":  "1",
+			"targetRoot":       "1",
+			"aggregatedCount":  "1",
+		},
+		Error: errors.New("failed to attestation"),
+	})
+	a.AddFailure(FailedAttestation{
+		Fields: logrus.Fields{
+			"slot":             "2",
+			"committeeCount":   "2",
+			"committeeIndices": "2",
+			"beaconBlockRoot":  "2",
+			"targetRoot":       "2",
+			"aggregatedCount":  "2",
+		},
+		Error: errors.New("failed to attestation"),
+	})
+
+	a.ReportEpochTransition(1)
+
+	assert.LogsContain(t, hook,
+		`"Attestation Summary for Epoch 1:" prefix=blockchain`,
+	)
+	assert.LogsContain(t, hook,
+		`"  Successful Attestations Count: 2" prefix=blockchain`,
+	)
+	assert.LogsContain(t, hook,
+		`"  Failed Attestations Count: 2" prefix=blockchain`,
+	)
+	assert.LogsContain(t, hook,
+		`"  error: failed to attestation" aggregatedCount=1 beaconBlockRoot=1 committeeCount=1 committeeIndices=1 prefix=blockchain slot=1 targetRoot=1`,
+	)
+	assert.LogsContain(t, hook,
+		`"  error: failed to attestation" aggregatedCount=2 beaconBlockRoot=2 committeeCount=2 committeeIndices=2 prefix=blockchain slot=2 targetRoot=2`,
+	)
+
+	hook = logtest.NewGlobal()
+	a.AddSuccess()
+	a.AddSuccess()
+	a.AddSuccess()
+	a.AddSuccess()
+	a.AddSuccess()
+	a.AddSuccess()
+
+	a.ReportEpochTransition(2)
+	assert.LogsContain(t, hook,
+		`"Attestation Summary for Epoch 2:" prefix=blockchain`,
+	)
+	assert.LogsContain(t, hook,
+		`"  Successful Attestations Count: 6" prefix=blockchain`,
+	)
+	assert.LogsContain(t, hook,
+		`"  Failed Attestations Count: 0" prefix=blockchain`,
+	)
+}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -211,6 +211,23 @@ func (s *Service) processAttestations(ctx context.Context, disparity time.Durati
 				}
 			}
 			log.WithFields(fields).WithError(err).Warn("Could not process attestation for fork choice")
+
+			// check if attestationsStats is null first
+			// to ensure it is initiated
+			// add failed count, attestation details and error to AttestationsStats
+			if s.attestationsStats != nil {
+				s.attestationsStats.AddFailure(FailedAttestation{
+					Fields: fields,
+					Error:  err,
+				})
+			}
+		}
+
+		// check if attestationsStats is null first
+		// to ensure it is initiated
+		// add successful count to AttestationsStats
+		if s.attestationsStats != nil {
+			s.attestationsStats.AddSuccess()
 		}
 	}
 }

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	consensus_blocks "github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
 	consensusblocks "github.com/prysmaticlabs/prysm/v5/consensus-types/blocks"
@@ -169,6 +170,15 @@ func (s *Service) updateCheckpoints(
 		}
 		if err := reportEpochMetrics(ctx, postState, headSt); err != nil {
 			log.WithError(err).Error("could not report epoch metrics")
+		}
+
+		// Check if attestationsStats is null first
+		// to ensure it is initiated
+		// Generate report for the attestationsStats for every epoch
+		// it is used to debug this node if it is verfying attestation correctly
+		if s.attestationsStats != nil {
+			currentEpoch := primitives.Epoch(postState.Slot() / params.BeaconConfig().SlotsPerEpoch)
+			s.attestationsStats.ReportEpochTransition(uint64(currentEpoch))
 		}
 	}
 	if err := s.updateJustificationOnBlock(ctx, preState, postState, cp.j); err != nil {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -68,6 +68,7 @@ type Service struct {
 	blockBeingSynced              *currentlySyncingBlock
 	blobStorage                   *filesystem.BlobStorage
 	lastPublishedLightClientEpoch primitives.Epoch
+	attestationsStats             *AttestationsStats // for debugging
 }
 
 // config options for the service.
@@ -180,6 +181,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		blobNotifiers:        bn,
 		cfg:                  &config{},
 		blockBeingSynced:     &currentlySyncingBlock{roots: make(map[[32]byte]struct{})},
+		attestationsStats:    NewAttestationsStats(),
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {


### PR DESCRIPTION
Feature

**What does this PR do? Why is it needed?**
suspecting Prysm is not verifying attestations correctly. Add logging for the attestations.

- Counts successfully verified attestations.
- Counts failed attestations and records the reason for each failure.
- Outputs a summary of the collected data at the end of each epoch.

**Which issues(s) does this PR fix?**
Add logging for the attestations
